### PR TITLE
Instance mount db cleanup

### DIFF
--- a/count.sql
+++ b/count.sql
@@ -1,0 +1,6 @@
+select count(m.id)
+from mount m
+join instance i on m.instance_id = i.id
+join volume v on m.volume_id = v.id
+where i.state = 'purged'
+and (v.data like '%"isHostPath":true%' or v.data like '%"driver":"local"%');

--- a/delete.sql
+++ b/delete.sql
@@ -1,0 +1,11 @@
+delete m
+from mount as m
+join (
+	select mm.id 
+	from mount as mm
+	join instance as i on mm.instance_id = i.id
+	join volume as v on mm.volume_id = v.id
+	where i.state = 'purged'
+	and (v.data like '%"isHostPath":true%' or v.data like '%"driver":"local"%')
+	limit 1000
+) mx on m.id = mx.id;

--- a/env_vars
+++ b/env_vars
@@ -1,0 +1,5 @@
+export SQL_FIX_USER=
+export SQL_FIX_PASSWORD=
+export SQL_FIX_HOST=
+export SQL_FIX_PORT=
+export SQL_FIX_DB=

--- a/fix.sh
+++ b/fix.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ret=$(mysql -u $SQL_FIX_USER  -p$SQL_FIX_PASSWORD -h $SQL_FIX_HOST -P $SQL_FIX_PORT --skip-column-names $SQL_FIX_DB < count.sql)
+echo "Initial row count: $ret"
+
+while [ $ret -gt 0 ]
+do
+  echo "Rows left: $ret"
+  mysql -u $SQL_FIX_USER -p$SQL_FIX_PASSWORD -h $SQL_FIX_HOST -P $SQL_FIX_PORT --skip-column-names $SQL_FIX_DB < delete.sql
+  ret=$(mysql -u $SQL_FIX_USER -p$SQL_FIX_PASSWORD -h $SQL_FIX_HOST -P $SQL_FIX_PORT --skip-column-names $SQL_FIX_DB < count.sql)
+done


### PR DESCRIPTION
### Instance mount cleanup
This script removes rows from the mount table that point to instances in the purged state and to volumes that are for local host bind mounts or anonymous docker volumes.

After this script is ran, the TableCleanup task must run in Rancher for the rows in the instance table to be removed. This task runs every hour but can be configured to run more frequently by setting the `task.table.cleanup.schedule` setting. You can set it in the API UI by opening a browser to `<rancher_url>/v2-beta/settings/task.table.cleanup.schedule`. The setting is in seconds, so setting it to 60 will cause the task to run every minute.

This logic will be added to the rancher code base and ran automatically with the rest of Rancher's cleanup logic, but this script can be used to address an immediate need to reduce the number of rows in the instance table.

### Usage
Set appropriate environment variables in env_vars file and source it: . env_vars
Run the script: ./fix.sh